### PR TITLE
data loading utils, other typing cosmetic enhancements, expansion of model config params

### DIFF
--- a/models/cross_attention_bidirectional.py
+++ b/models/cross_attention_bidirectional.py
@@ -2,6 +2,7 @@ from typing import override
 
 import torch
 import torch.nn as nn
+
 from models.model_config import ModelConfig
 
 
@@ -13,32 +14,40 @@ class CrossAttentionBidirectional(nn.Module):
     Forward output shape: (B, 64)
     """
 
+    modelList: nn.ModuleDict
+
     def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
-        self.modelList: nn.ModuleDict = nn.ModuleDict(
+        self.modelList = nn.ModuleDict(
             {
                 "cross_attn_to_actions": nn.MultiheadAttention(
-                    config.cross_attention['d_model'], 
-                    num_heads=config.cross_attention['num_heads'], 
-                    batch_first=True
+                    config.cross_attention["d_model"],
+                    num_heads=config.cross_attention["num_heads"],
+                    batch_first=True,
                 ),
                 "cross_attn_to_cards": nn.MultiheadAttention(
-                    config.cross_attention['d_model'], 
-                    num_heads=config.cross_attention['num_heads'], 
-                    batch_first=True
+                    config.cross_attention["d_model"],
+                    num_heads=config.cross_attention["num_heads"],
+                    batch_first=True,
                 ),
             }
         )
 
     @override
-    def forward(self, x_actions: torch.LongTensor, x_cards: torch.LongTensor) -> torch.Tensor:
+    def forward(
+        self, x_actions: torch.LongTensor, x_cards: torch.LongTensor
+    ) -> torch.Tensor:
         # Actions attend to cards
-        y_actions = self.modelList["cross_attn_to_actions"](x_actions, x_cards, x_cards)[0]
-        
+        y_actions: torch.Tensor = self.modelList["cross_attn_to_actions"](
+            x_actions, x_cards, x_cards
+        )[0]
+
         # Cards attend to actions
-        y_cards = self.modelList["cross_attn_to_cards"](x_cards, x_actions, x_actions)[0]
-        
+        y_cards: torch.Tensor = self.modelList["cross_attn_to_cards"](
+            x_cards, x_actions, x_actions
+        )[0]
+
         # Pool and concatenate
-        y_actions_pooled = y_actions.mean(dim=1)  # (B, 32)
-        y_cards_pooled = y_cards.mean(dim=1)      # (B, 32)
+        y_actions_pooled: torch.Tensor = y_actions.mean(dim=1)  # (B, 32)
+        y_cards_pooled: torch.Tensor = y_cards.mean(dim=1)  # (B, 32)
         return torch.cat((y_actions_pooled, y_cards_pooled), dim=-1)  # (B, 64)

--- a/models/encoded_handhistory.py
+++ b/models/encoded_handhistory.py
@@ -1,7 +1,9 @@
-from typing import List, Dict
-import numpy as np
 import json
-from models.handhistory import HandHistory, Action, Player, Street, Actor, GameAction
+
+import torch
+
+from models.handhistory import Action, Actor, GameAction, HandHistory, Player, Street
+
 
 class EncodedHandHistory:
     """
@@ -10,84 +12,85 @@ class EncodedHandHistory:
     """
 
     # Preflop bet size buckets
-    
+
     # Postflop bet size buckets (as percentages of pot)
-    POSTFLOP_BET_BUCKETS = [0.25, 0.5, 0.75, 1.0, 1.5, float('inf')]
-    
+    POSTFLOP_BET_BUCKETS = [0.25, 0.5, 0.75, 1.0, 1.5, float("inf")]
+
     # Only need mappings for card notation
     RANK_MAP = {
-        '2': 0, '3': 1, '4': 2, '5': 3, '6': 4, '7': 5, '8': 6,
-        '9': 7, 'T': 8, '10': 8, 'J': 9, 'Q': 10, 'K': 11, 'A': 12
-    }
-    
-    SUIT_MAP = {
-        's': 0,  # Spade
-        'h': 1,  # Heart
-        'd': 2,  # Diamond
-        'c': 3   # Club
-    }
-    
-    CARD_STREET_MAP = {
-        'hole': 0,
-        'flop': 1,
-        'turn': 2,
-        'river': 3
+        "2": 0,
+        "3": 1,
+        "4": 2,
+        "5": 3,
+        "6": 4,
+        "7": 5,
+        "8": 6,
+        "9": 7,
+        "T": 8,
+        "10": 8,
+        "J": 9,
+        "Q": 10,
+        "K": 11,
+        "A": 12,
     }
 
-    
+    SUIT_MAP = {"s": 0, "h": 1, "d": 2, "c": 3}  # Spade  # Heart  # Diamond  # Club
+
+    CARD_STREET_MAP = {"hole": 0, "flop": 1, "turn": 2, "river": 3}
+
     @classmethod
-    def encode_hand_history(cls, hand_history: HandHistory) -> Dict[str, np.ndarray]:
+    def encode_hand_history(
+        cls, hand_history: HandHistory
+    ) -> dict[str, torch.LongTensor]:
         """
         Encode a HandHistory object into the format needed for the neural network.
-        
+
         Args:
             hand_history: A HandHistory object containing the raw hand data
-            
+
         Returns:
             A dictionary containing encoded actions and cards
         """
         encoded_actions = cls._encode_actions(hand_history.gameLog)
         encoded_cards = cls._encode_cards(hand_history.hand, hand_history.board)
-        
-        return {
-            'actions': encoded_actions,
-            'cards': encoded_cards
-        }
-    
+
+        return {"actions": encoded_actions, "cards": encoded_cards}
+
     @classmethod
-    def encode_batch(cls, hand_histories: List[HandHistory]) -> List[Dict[str, np.ndarray]]:
+    def encode_batch(
+        cls, hand_histories: list[HandHistory]
+    ) -> list[dict[str, torch.LongTensor]]:
         """
         Encode a batch of HandHistory objects.
-        
+
         Args:
             hand_histories: A list of HandHistory objects
-            
+
         Returns:
             A list of dictionaries, each containing encoded actions and cards
         """
         return [cls.encode_hand_history(hh) for hh in hand_histories]
-    
+
     @staticmethod
-    def _encode_actions(game_log: List[GameAction]) -> np.ndarray:
+    def _encode_actions(game_log: list[GameAction]) -> torch.LongTensor:
         """
         Encode the game actions into the format needed for the neural network.
-        
+
         Args:
             game_log: A list of GameAction objects
-            
+
         Returns:
-            A numpy array of shape (T, 5) where T is the number of actions
+            A torch.LongTensor of shape (T, 5) where T is the number of actions
             Each row contains [actor_idx, action_idx, bet_size_bucket_idx, street_idx, position_idx]
         """
-        encoded = []
-        
+        encoded_actions: list[torch.LongTensor] = []
+
         for action in game_log:
             # Get indices directly from enum values
             actor_idx = action.actor.value
             action_idx = action.action.value
             street_idx = action.street.value
             position_idx = action.player.value
-            
 
             # For preflop, ignore bet sizing
             if action.street == Street.PREFLOP:
@@ -100,103 +103,106 @@ class EncodedHandHistory:
                     if bet_size <= threshold:
                         bet_size_bucket_idx = i
                         break
-            
-            action_vector = np.array([
-                actor_idx,
-                action_idx,
-                bet_size_bucket_idx,
-                street_idx,
-                position_idx
-            ])
-            
-            encoded.append(action_vector)
-        
-        return np.array(encoded)
-    
+
+            action_vector = torch.LongTensor(
+                [actor_idx, action_idx, bet_size_bucket_idx, street_idx, position_idx]
+            )
+
+            encoded_actions.append(action_vector)
+
+        if len(encoded_actions) == 0:  # torch stack needs non-empty input
+            return torch.LongTensor([])
+        else:
+            return torch.stack(encoded_actions)
+
     @staticmethod
-    def _encode_cards(hand: List[str], board: List[str]) -> np.ndarray:
+    def _encode_cards(hand: list[str], board: list[str]) -> torch.LongTensor:
         """
         Encode the hole cards and board cards into the format needed for the neural network.
-        
+
         Args:
             hand: A list of strings representing the hole cards
             board: A list of strings representing the board cards
-            
+
         Returns:
-            A numpy array of shape (7, 3) where 7 is the total number of cards
+            A torch.LongTensor of shape (7, 3) where 7 is the total number of cards
             Each row contains [rank_idx, suit_idx, street_idx]
         """
         encoded_cards = []
-        
+
         # Encode hole cards
         for card in hand:
             rank = card[0]
             suit = card[1]
-            
+
             # Get indices directly
             rank_idx = EncodedHandHistory.RANK_MAP[rank]
             suit_idx = EncodedHandHistory.SUIT_MAP[suit]
-            street_idx = EncodedHandHistory.CARD_STREET_MAP['hole']
-            
-            card_encoding = np.array([rank_idx, suit_idx, street_idx])
+            street_idx = EncodedHandHistory.CARD_STREET_MAP["hole"]
+
+            card_encoding = torch.LongTensor([rank_idx, suit_idx, street_idx])
             encoded_cards.append(card_encoding)
-        
+
         # Encode board cards
         for i, card in enumerate(board):
             rank = card[0]
             suit = card[1]
-            
+
             # Get indices directly
             rank_idx = EncodedHandHistory.RANK_MAP[rank]
             suit_idx = EncodedHandHistory.SUIT_MAP[suit]
-            
+
             # Determine street based on position in board
             if i < 3:
-                street_idx = EncodedHandHistory.CARD_STREET_MAP['flop']
+                street_idx = EncodedHandHistory.CARD_STREET_MAP["flop"]
             elif i == 3:
-                street_idx = EncodedHandHistory.CARD_STREET_MAP['turn']
+                street_idx = EncodedHandHistory.CARD_STREET_MAP["turn"]
             else:
-                street_idx = EncodedHandHistory.CARD_STREET_MAP['river']
-            
-            card_encoding = np.array([rank_idx, suit_idx, street_idx])
+                street_idx = EncodedHandHistory.CARD_STREET_MAP["river"]
+
+            card_encoding = torch.LongTensor([rank_idx, suit_idx, street_idx])
             encoded_cards.append(card_encoding)
-        
-        return np.array(encoded_cards)
-    
+
+        if len(encoded_cards) == 0:  # torch stack needs non-empty input
+            return torch.LongTensor([])
+        else:
+            return torch.stack(encoded_cards)
+
     @classmethod
-    def from_json(cls, json_file: str) -> Dict[str, np.ndarray]:
+    def from_json(cls, json_file: str) -> dict[str, torch.LongTensor]:
         """
         Create encoded hand history from a JSON file.
-        
+
         Args:
             json_file: Path to the JSON file
-            
+
         Returns:
             A dictionary containing encoded actions and cards
         """
-        with open(json_file, 'r') as f:
+        with open(json_file, "r") as f:
             data = json.load(f)
-        
+
         # Convert string values to enum values
-        hand = data['hand']
-        board = data['board']
-        
+        hand = data["hand"]
+        board = data["board"]
+
         game_log = []
-        for action_data in data['gameLog']:
+        for action_data in data["gameLog"]:
             # Convert string values to enum values
-            action = Action[action_data['action'].upper()]
-            player = Player[action_data['player'].replace(' ', '_').upper()]
-            street = Street[action_data['street'].upper()]
-            actor = Actor[action_data['actor'].upper()]
-            
+            action = Action[action_data["action"].upper()]
+            player = Player[action_data["player"].replace(" ", "_").upper()]
+            street = Street[action_data["street"].upper()]
+            actor = Actor[action_data["actor"].upper()]
+
             game_action = GameAction(
                 action=action,
-                amount=action_data['amount'],
+                amount=action_data["amount"],
                 player=player,
                 street=street,
-                actor=actor
+                actor=actor,
             )
             game_log.append(game_action)
-        
+
         hand_history = HandHistory(hand=hand, board=board, gameLog=game_log)
-        return cls.encode_hand_history(hand_history) 
+        return cls.encode_hand_history(hand_history)
+

--- a/models/encoded_handhistory.py
+++ b/models/encoded_handhistory.py
@@ -1,8 +1,14 @@
 import json
+from typing import TypedDict
 
 import torch
 
 from models.handhistory import Action, Actor, GameAction, HandHistory, Player, Street
+
+
+class EncodedHandHistoryType(TypedDict):
+    actions: torch.LongTensor
+    cards: torch.LongTensor
 
 
 class EncodedHandHistory:
@@ -39,9 +45,7 @@ class EncodedHandHistory:
     CARD_STREET_MAP = {"hole": 0, "flop": 1, "turn": 2, "river": 3}
 
     @classmethod
-    def encode_hand_history(
-        cls, hand_history: HandHistory
-    ) -> dict[str, torch.LongTensor]:
+    def encode_hand_history(cls, hand_history: HandHistory) -> EncodedHandHistoryType:
         """
         Encode a HandHistory object into the format needed for the neural network.
 
@@ -59,7 +63,7 @@ class EncodedHandHistory:
     @classmethod
     def encode_batch(
         cls, hand_histories: list[HandHistory]
-    ) -> list[dict[str, torch.LongTensor]]:
+    ) -> list[EncodedHandHistoryType]:
         """
         Encode a batch of HandHistory objects.
 
@@ -169,7 +173,7 @@ class EncodedHandHistory:
             return torch.stack(encoded_cards)
 
     @classmethod
-    def from_json(cls, json_file: str) -> dict[str, torch.LongTensor]:
+    def from_json(cls, json_file: str) -> EncodedHandHistoryType:
         """
         Create encoded hand history from a JSON file.
 
@@ -205,4 +209,3 @@ class EncodedHandHistory:
 
         hand_history = HandHistory(hand=hand, board=board, gameLog=game_log)
         return cls.encode_hand_history(hand_history)
-

--- a/models/encoders.py
+++ b/models/encoders.py
@@ -10,14 +10,17 @@ from utils.custom_nn_modules import CombinedEncoder, DoNothingEncoder, OneHotEnc
 class ActionSequenceEncoder(nn.Module):
     """
     Encoder encoding action sequence with self-attention.
-    Forward input shape: (B, T, 5)
-    Forward output shape: (B, T, 32)
+    Forward input shape: T = max seq length
+        - input tensor: (B, T, 5), torch.LongTensor
+        - mask tensor: (B, T), torch.BoolTensor
+    Forward output shape: (B, T, 32), torch.Tensor
     """
 
+    encoder_output_dim: int
     encoder: nn.Module
     fc_layers: nn.Module
     transformer_encoder: nn.Module
-    model: nn.Module
+    model: nn.ModuleList
 
     def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
@@ -27,19 +30,19 @@ class ActionSequenceEncoder(nn.Module):
         action_type_encoder = nn.Embedding(
             config.action_encoder["num_actions"],
             config.action_encoder["action_embedding_dim"],
-        )  # 4
+        )  # default output dim: 4
 
         bet_size_bucket_encoder = OneHotEncoder(6)  # 6
 
         street_encoder = nn.Embedding(
             config.action_encoder["num_streets"],
             config.action_encoder["street_embedding_dim"],
-        )  # 4
+        )  # default output dim: 4
 
         position_encoder = nn.Embedding(
             config.action_encoder["num_positions"],
             config.action_encoder["position_embedding_dim"],
-        )  # 4
+        )  # default output dim: 4
         encoder_list = [
             actor_encoder,
             action_type_encoder,
@@ -49,8 +52,22 @@ class ActionSequenceEncoder(nn.Module):
         ]
         action_sequence_encoder = CombinedEncoder(encoder_list)
         self.encoder = action_sequence_encoder
+        self.encoder_output_dim = (
+            1
+            + 6
+            + sum(
+                [
+                    config.action_encoder[k]
+                    for k in (
+                        "action_embedding_dim",
+                        "street_embedding_dim",
+                        "position_embedding_dim",
+                    )
+                ]
+            )
+        )
         self.fc_layers = nn.Sequential(
-            nn.Linear(19, config.action_encoder["d_model"]),
+            nn.Linear(self.encoder_output_dim, config.action_encoder["d_model"]),
             nn.ReLU(),
             nn.Linear(
                 config.action_encoder["d_model"], config.action_encoder["d_model"]
@@ -66,30 +83,42 @@ class ActionSequenceEncoder(nn.Module):
             batch_first=True,
         )
 
-        self.model = nn.Sequential(
-            self.encoder,  # Initial encoding
-            self.fc_layers,  # Process encoded features
-            self.transformer_encoder,  # Self-attention
+        self.model = nn.ModuleList(
+            [
+                self.encoder,  # Initial encoding
+                self.fc_layers,  # Process encoded features
+                self.transformer_encoder,  # Self-attention
+            ],
         )
 
     @override
-    def forward(self, x: torch.LongTensor) -> torch.Tensor:
-        x = self.model(x)  # (B, T, 32)
-
-        return x
+    def forward(
+        self, x: torch.LongTensor, x_mask: torch.BoolTensor | None = None
+    ) -> torch.Tensor:
+        x_after_initial_encoding: torch.Tensor = self.model[0](
+            x
+        )  # (B, T, 5) -> (B, T, encoder_output_dim)
+        x_after_fc: torch.Tensor = self.model[1](
+            x_after_initial_encoding
+        )  # -> (B, T, config.action_encoder["d_model"])
+        x_after_self_attention: torch.Tensor = self.model[2](
+            x_after_fc, src_key_padding_mask=x_mask
+        )  # -> same dim
+        return x_after_self_attention
 
 
 class CardSequenceEncoder(nn.Module):
     """
     Encoder encoding card sequence with self-attention.
-    Forward input shape: (B, 7, 3)
-    Forward output shape: (B, 7, 32)
+    Forward input shape: (B, 7, 3), torch.LongTensor
+    Forward output shape: (B, 7, 32), torch.Tensor
     """
 
+    encoder_output_dim: int
     encoder: nn.Module
     fc_layers: nn.Module
     transformer_encoder: nn.Module
-    model: nn.Module
+    model: nn.ModuleList
 
     def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
@@ -109,8 +138,20 @@ class CardSequenceEncoder(nn.Module):
         encoder_list = [rank_encoder, suit_encoder, street_encoder]
         hand_evaluator_encoder = CombinedEncoder(encoder_list)
         self.encoder = hand_evaluator_encoder
+        self.encoder_output_dim = sum(
+            [
+                config.card_encoder[k]
+                for k in (
+                    "rank_embedding_dim",
+                    "suit_embedding_dim",
+                    "street_embedding_dim",
+                )
+            ]
+        )
         self.fc_layers = nn.Sequential(
-            nn.Linear(16, 24), nn.ReLU(), nn.Linear(24, config.card_encoder["d_model"])
+            nn.Linear(self.encoder_output_dim, config.card_encoder["d_model"]),
+            nn.ReLU(),
+            nn.Linear(config.card_encoder["d_model"], config.card_encoder["d_model"]),
         )
 
         # Add transformer encoder layer for self-attention
@@ -122,14 +163,21 @@ class CardSequenceEncoder(nn.Module):
             batch_first=True,
         )
 
-        self.model = nn.Sequential(
-            self.encoder,  # Initial encoding
-            self.fc_layers,  # Process encoded features
-            self.transformer_encoder,  # Self-attention
+        self.model = nn.ModuleList(
+            [
+                self.encoder,  # Initial encoding
+                self.fc_layers,  # Process encoded features
+                self.transformer_encoder,  # Self-attention
+            ]
         )
 
     @override
     def forward(self, x: torch.LongTensor) -> torch.Tensor:
-        x = self.model(x)  # (B, 7, 32)
-
-        return x
+        x_after_initial_encoding: torch.Tensor = self.model[0](
+            x
+        )  # (B, T, 5) -> (B, T, encoder_output_dim)
+        x_after_fc: torch.Tensor = self.model[1](
+            x_after_initial_encoding
+        )  # -> (B, T, config.card_encoder["d_model"])
+        x_after_self_attention: torch.Tensor = self.model[2](x_after_fc)  # -> same dim
+        return x_after_self_attention

--- a/models/encoders.py
+++ b/models/encoders.py
@@ -2,10 +2,9 @@ from typing import override
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
-from utils.custom_nn_modules import CombinedEncoder, DoNothingEncoder, OneHotEncoder
 from models.model_config import ModelConfig
+from utils.custom_nn_modules import CombinedEncoder, DoNothingEncoder, OneHotEncoder
 
 
 class ActionSequenceEncoder(nn.Module):
@@ -15,21 +14,32 @@ class ActionSequenceEncoder(nn.Module):
     Forward output shape: (B, T, 32)
     """
 
+    encoder: nn.Module
+    fc_layers: nn.Module
+    transformer_encoder: nn.Module
+    model: nn.Module
+
     def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
 
-        actor_encoder = DoNothingEncoder() # 1
+        actor_encoder = DoNothingEncoder()  # 1
 
-        action_type_encoder = nn.Embedding(config.action_encoder['num_actions'], 
-                                         config.action_encoder['action_embedding_dim']) # 4
-        
-        bet_size_bucket_encoder = OneHotEncoder(6) # 6
+        action_type_encoder = nn.Embedding(
+            config.action_encoder["num_actions"],
+            config.action_encoder["action_embedding_dim"],
+        )  # 4
 
-        street_encoder = nn.Embedding(config.action_encoder['num_streets'], 
-                                    config.action_encoder['street_embedding_dim']) # 4
-        
-        position_encoder = nn.Embedding(config.action_encoder['num_positions'], 
-                                      config.action_encoder['position_embedding_dim']) # 4
+        bet_size_bucket_encoder = OneHotEncoder(6)  # 6
+
+        street_encoder = nn.Embedding(
+            config.action_encoder["num_streets"],
+            config.action_encoder["street_embedding_dim"],
+        )  # 4
+
+        position_encoder = nn.Embedding(
+            config.action_encoder["num_positions"],
+            config.action_encoder["position_embedding_dim"],
+        )  # 4
         encoder_list = [
             actor_encoder,
             action_type_encoder,
@@ -39,30 +49,33 @@ class ActionSequenceEncoder(nn.Module):
         ]
         action_sequence_encoder = CombinedEncoder(encoder_list)
         self.encoder = action_sequence_encoder
-        self.fc_layers = nn.Sequential(nn.Linear(19, config.action_encoder['d_model']), 
-                                     nn.ReLU(), 
-                                     nn.Linear(config.action_encoder['d_model'], 
-                                             config.action_encoder['d_model']))
-        
+        self.fc_layers = nn.Sequential(
+            nn.Linear(19, config.action_encoder["d_model"]),
+            nn.ReLU(),
+            nn.Linear(
+                config.action_encoder["d_model"], config.action_encoder["d_model"]
+            ),
+        )
+
         # Add transformer encoder layer for self-attention
         self.transformer_encoder = nn.TransformerEncoderLayer(
-            d_model=config.action_encoder['d_model'],
-            nhead=config.action_encoder['nhead'],
-            dim_feedforward=config.action_encoder['dim_feedforward'],
-            dropout=config.action_encoder['dropout'],
-            batch_first=True
+            d_model=config.action_encoder["d_model"],
+            nhead=config.action_encoder["nhead"],
+            dim_feedforward=config.action_encoder["dim_feedforward"],
+            dropout=config.action_encoder["dropout"],
+            batch_first=True,
         )
-        
+
         self.model = nn.Sequential(
-            self.encoder,           # Initial encoding
-            self.fc_layers,        # Process encoded features
-            self.transformer_encoder  # Self-attention
+            self.encoder,  # Initial encoding
+            self.fc_layers,  # Process encoded features
+            self.transformer_encoder,  # Self-attention
         )
 
     @override
     def forward(self, x: torch.LongTensor) -> torch.Tensor:
         x = self.model(x)  # (B, T, 32)
-        
+
         return x
 
 
@@ -73,41 +86,50 @@ class CardSequenceEncoder(nn.Module):
     Forward output shape: (B, 7, 32)
     """
 
+    encoder: nn.Module
+    fc_layers: nn.Module
+    transformer_encoder: nn.Module
+    model: nn.Module
+
     def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
-        rank_encoder = nn.Embedding(config.card_encoder['num_ranks'], 
-                                    config.card_encoder['rank_embedding_dim']) # 8
-        
-        suit_encoder = nn.Embedding(config.card_encoder['num_suits'],  
-                                    config.card_encoder['suit_embedding_dim']) # 4
-        
-        street_encoder = nn.Embedding(config.card_encoder['num_streets'],  
-                                      config.card_encoder['street_embedding_dim']) # 4
-        
+        rank_encoder = nn.Embedding(
+            config.card_encoder["num_ranks"], config.card_encoder["rank_embedding_dim"]
+        )  # 8
+
+        suit_encoder = nn.Embedding(
+            config.card_encoder["num_suits"], config.card_encoder["suit_embedding_dim"]
+        )  # 4
+
+        street_encoder = nn.Embedding(
+            config.card_encoder["num_streets"],
+            config.card_encoder["street_embedding_dim"],
+        )  # 4
+
         encoder_list = [rank_encoder, suit_encoder, street_encoder]
         hand_evaluator_encoder = CombinedEncoder(encoder_list)
         self.encoder = hand_evaluator_encoder
-        self.fc_layers = nn.Sequential(nn.Linear(16, 24), 
-                                     nn.ReLU(), 
-                                     nn.Linear(24, config.card_encoder['d_model']))
-        
+        self.fc_layers = nn.Sequential(
+            nn.Linear(16, 24), nn.ReLU(), nn.Linear(24, config.card_encoder["d_model"])
+        )
+
         # Add transformer encoder layer for self-attention
         self.transformer_encoder = nn.TransformerEncoderLayer(
-            d_model=config.card_encoder['d_model'],
-            nhead=config.card_encoder['nhead'],
-            dim_feedforward=config.card_encoder['dim_feedforward'],
-            dropout=config.card_encoder['dropout'],
-            batch_first=True
+            d_model=config.card_encoder["d_model"],
+            nhead=config.card_encoder["nhead"],
+            dim_feedforward=config.card_encoder["dim_feedforward"],
+            dropout=config.card_encoder["dropout"],
+            batch_first=True,
         )
-        
+
         self.model = nn.Sequential(
-            self.encoder,           # Initial encoding
-            self.fc_layers,        # Process encoded features
-            self.transformer_encoder  # Self-attention
+            self.encoder,  # Initial encoding
+            self.fc_layers,  # Process encoded features
+            self.transformer_encoder,  # Self-attention
         )
 
     @override
     def forward(self, x: torch.LongTensor) -> torch.Tensor:
         x = self.model(x)  # (B, 7, 32)
-        
+
         return x

--- a/models/full_model.py
+++ b/models/full_model.py
@@ -15,6 +15,8 @@ class FullModel(nn.Module):
     Forward output shape: (B, ) (torch.Tensor)
     """
 
+    moduleDict: nn.ModuleDict
+
     def __init__(self) -> None:
         super().__init__()
         self.moduleDict = nn.ModuleDict(
@@ -32,8 +34,10 @@ class FullModel(nn.Module):
         x_actions: torch.LongTensor,
         x_cards: torch.LongTensor,
     ) -> torch.Tensor:
-        x_enc_actions = self.moduleDict["encoder_actions"](x_actions)
-        x_enc_cards = self.moduleDict["encoder_cards"](x_cards)
-        x_attended = self.moduleDict["cross_attention"](x_enc_actions, x_enc_cards)
-        predicted_ev = self.moduleDict["output_mlp"](x_attended)
+        x_enc_actions: torch.Tensor = self.moduleDict["encoder_actions"](x_actions)
+        x_enc_cards: torch.Tensor = self.moduleDict["encoder_cards"](x_cards)
+        x_attended: torch.Tensor = self.moduleDict["cross_attention"](
+            x_enc_actions, x_enc_cards
+        )
+        predicted_ev: torch.Tensor = self.moduleDict["output_mlp"](x_attended)
         return predicted_ev

--- a/models/full_model.py
+++ b/models/full_model.py
@@ -3,6 +3,8 @@ from typing import override
 import torch
 import torch.nn as nn
 
+from models.model_config import ModelConfig
+
 from .cross_attention_bidirectional import CrossAttentionBidirectional
 from .encoders import ActionSequenceEncoder, CardSequenceEncoder
 from .output_mlp import OutputMLP
@@ -11,19 +13,22 @@ from .output_mlp import OutputMLP
 class FullModel(nn.Module):
     """
     FullModel combining encoders, cross attention, outputMLP
-    Forward input shapes: (B, T, 5), (B, 7, 3) for action and output (torch.LongTensor)
+    Forward input shapes:
+        - (B, T, 5) for action (torch.LongTensor), where T is max seq length
+        - (B, 7, 3) for output (torch.LongTensor)
+        - (B, T) for output (torch.LongTensor)
     Forward output shape: (B, ) (torch.Tensor)
     """
 
     moduleDict: nn.ModuleDict
 
-    def __init__(self) -> None:
+    def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
         self.moduleDict = nn.ModuleDict(
             {
-                "encoder_actions": ActionSequenceEncoder(),
-                "encoder_cards": CardSequenceEncoder(),
-                "cross_attention": CrossAttentionBidirectional(),
+                "encoder_actions": ActionSequenceEncoder(config=config),
+                "encoder_cards": CardSequenceEncoder(config=config),
+                "cross_attention": CrossAttentionBidirectional(config=config),
                 "output_mlp": OutputMLP(),
             }
         )
@@ -33,11 +38,14 @@ class FullModel(nn.Module):
         self,
         x_actions: torch.LongTensor,
         x_cards: torch.LongTensor,
+        x_actions_mask: torch.BoolTensor | None = None,
     ) -> torch.Tensor:
-        x_enc_actions: torch.Tensor = self.moduleDict["encoder_actions"](x_actions)
+        x_enc_actions: torch.Tensor = self.moduleDict["encoder_actions"](
+            x_actions, x_actions_mask
+        )
         x_enc_cards: torch.Tensor = self.moduleDict["encoder_cards"](x_cards)
         x_attended: torch.Tensor = self.moduleDict["cross_attention"](
-            x_enc_actions, x_enc_cards
+            x_enc_actions, x_enc_cards, x_actions_mask
         )
         predicted_ev: torch.Tensor = self.moduleDict["output_mlp"](x_attended)
         return predicted_ev

--- a/models/handhistory.py
+++ b/models/handhistory.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import List
 from enum import Enum
 
 
@@ -43,6 +42,7 @@ class GameAction:
 
 @dataclass
 class HandHistory:
-    hand: List[str]
-    board: List[str]
-    gameLog: List[GameAction]
+    hand: list[str]
+    board: list[str]
+    gameLog: list[GameAction]
+

--- a/models/model_config.py
+++ b/models/model_config.py
@@ -1,40 +1,76 @@
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import TypedDict
+
+
+class ActionEncoderConfig(TypedDict):
+    d_model: int
+    nhead: int
+    dim_feedforward: int
+    dropout: float
+    num_actions: int
+    num_positions: int
+    num_streets: int
+    action_embedding_dim: int
+    position_embedding_dim: int
+    street_embedding_dim: int
+
+
+class CardEncoderConfig(TypedDict):
+    d_model: int
+    nhead: int
+    dim_feedforward: int
+    dropout: float
+    num_ranks: int
+    num_suits: int
+    num_streets: int
+    rank_embedding_dim: int
+    suit_embedding_dim: int
+    street_embedding_dim: int
+
+
+class CrossAttentionConfig(TypedDict):
+    num_heads: int
+    d_model: int
+
 
 @dataclass
 class ModelConfig:
     """Configuration class for model hyperparameters."""
-    
+
     # Action Sequence Encoder
-    action_encoder: Dict[str, int] = field(default_factory=lambda: {
-        'd_model': 32,
-        'nhead': 4,
-        'dim_feedforward': 128,
-        'dropout': 0.1,
-        'num_actions': 5,
-        'num_positions': 6,
-        'num_streets': 5,
-        'action_embedding_dim': 4,
-        'position_embedding_dim': 4,
-        'street_embedding_dim': 4
-    })
-    
+    action_encoder: ActionEncoderConfig = field(
+        default_factory=lambda: {
+            "d_model": 32,
+            "nhead": 4,
+            "dim_feedforward": 128,
+            "dropout": 0.1,
+            "num_actions": 5,
+            "num_positions": 6,
+            "num_streets": 5,
+            "action_embedding_dim": 4,
+            "position_embedding_dim": 4,
+            "street_embedding_dim": 4,
+        }
+    )
+
     # Card Sequence Encoder
-    card_encoder: Dict[str, int] = field(default_factory=lambda: {
-        'd_model': 32,
-        'nhead': 4,
-        'dim_feedforward': 128,
-        'dropout': 0.1,
-        'num_ranks': 13,
-        'num_suits': 4,
-        'num_streets': 4,
-        'rank_embedding_dim': 8,
-        'suit_embedding_dim': 4,
-        'street_embedding_dim': 4
-    })
-    
+    card_encoder: CardEncoderConfig = field(
+        default_factory=lambda: {
+            "d_model": 32,
+            "nhead": 4,
+            "dim_feedforward": 128,
+            "dropout": 0.1,
+            "num_ranks": 13,
+            "num_suits": 4,
+            "num_streets": 4,
+            "rank_embedding_dim": 8,
+            "suit_embedding_dim": 4,
+            "street_embedding_dim": 4,
+        }
+    )
+
     # Cross Attention
-    cross_attention: Dict[str, int] = field(default_factory=lambda: {
-        'num_heads': 4,
-        'd_model': 32
-    })    
+    cross_attention: CrossAttentionConfig = field(
+        default_factory=lambda: {"num_heads": 4, "d_model": 32}
+    )
+

--- a/models/output_mlp.py
+++ b/models/output_mlp.py
@@ -3,26 +3,31 @@ from typing import override
 import torch
 import torch.nn as nn
 
+from models.model_config import ModelConfig
+
 
 class OutputMLP(nn.Module):
     """
     OutputHeadMLP layer predicting EV from concatenated attention outputs
-    Forward input shape: (B, 64)
+    Forward input shape: (B, 2 * d_model)
     Forward output shape: (B, )
     """
 
     model: nn.Module
 
-    def __init__(self) -> None:
+    def __init__(self, config: ModelConfig = ModelConfig()) -> None:
         super().__init__()
+        # default: input 64 -> 64 -> 32 -> 1
         self.model = nn.Sequential(
-            nn.Linear(64, 64),
+            nn.Linear(
+                2 * config.output_mlp["d_model"], 2 * config.output_mlp["d_model"]
+            ),
             nn.ReLU(),
             nn.Dropout(),
-            nn.Linear(64, 32),
+            nn.Linear(2 * config.output_mlp["d_model"], config.output_mlp["d_model"]),
             nn.ReLU(),
             nn.Dropout(),
-            nn.Linear(32, 1),
+            nn.Linear(config.output_mlp["d_model"], 1),
         )
 
     @override

--- a/models/output_mlp.py
+++ b/models/output_mlp.py
@@ -11,6 +11,8 @@ class OutputMLP(nn.Module):
     Forward output shape: (B, )
     """
 
+    model: nn.Module
+
     def __init__(self) -> None:
         super().__init__()
         self.model = nn.Sequential(

--- a/tests/test_create_mask_and_pad.py
+++ b/tests/test_create_mask_and_pad.py
@@ -1,0 +1,17 @@
+import torch
+
+from utils.create_mask_and_pad import MaskerPadder
+
+
+class TestCreateMask:
+    def test_masker(self):
+        masker_padder = MaskerPadder(validate_input=True)
+        for _ in range(3):
+            perm = torch.randperm(4)
+            x = [torch.ones((i, 10)).long() for i in range(1, 5)]
+            true_mask = torch.ones(4, 4).triu(diagonal=1).bool()[perm, :]
+
+            x_mask, x_padded = masker_padder([x[i] for i in perm])
+            assert x_mask.shape == true_mask.shape
+            assert x_mask.dtype == true_mask.dtype
+            assert torch.equal(x_mask, true_mask)

--- a/tests/test_custom_torch_data_utils.py
+++ b/tests/test_custom_torch_data_utils.py
@@ -1,0 +1,34 @@
+from torch.utils.data import DataLoader
+
+from models.full_model import FullModel
+from models.model_config import ModelConfig
+from utils.custom_torch_data_utils import (
+    CollateFnForJSONDatasetType,
+    JSONDatasetBase,
+    JSONDatasetType,
+)
+
+
+class TestCustomTorchDatasets:
+    def test_dataloader_and_forward_on_base_data(self):
+        config = ModelConfig()
+        config.training_process["batch_size"] = 16
+        dataset = JSONDatasetBase(config)
+        dataloader: DataLoader[JSONDatasetType] = DataLoader(
+            dataset,
+            batch_size=config.training_process["batch_size"],
+            shuffle=True,
+            num_workers=2,
+            collate_fn=CollateFnForJSONDatasetType,
+        )
+
+        # test if forward works
+        model = FullModel(config=config)
+        for i_batch, sample_batched in enumerate(dataloader):
+            if i_batch == 0:
+                print({k: v.shape for k, v in sample_batched.items()})
+            [expected_ev, x_cards, x_actions, x_actions_mask] = [
+                sample_batched[k]
+                for k in ("expected_ev", "cards", "actions_padded", "actions_mask")
+            ]
+            model.forward(x_actions, x_cards, x_actions_mask)

--- a/tests/test_encoded_handhistory.py
+++ b/tests/test_encoded_handhistory.py
@@ -1,8 +1,5 @@
 from pathlib import Path
 
-import numpy as np
-import pytest
-
 from models.encoded_handhistory import EncodedHandHistory
 from models.handhistory import Action, Actor, GameAction, HandHistory, Player, Street
 
@@ -250,7 +247,7 @@ class TestEncodedHandHistory:
     def test_sample_hand(self):
         """Test encoding of the sample hand from hand1.json"""
         test_dir = Path(__file__).parent
-        sample_json_file = str((test_dir / "sample-hand") / "hand1.json")
+        sample_json_file = str(test_dir / "sample-hand" / "hand1.json")
         encoded = EncodedHandHistory.from_json(sample_json_file)
 
         # Check action encoding
@@ -347,4 +344,3 @@ class TestEncodedHandHistory:
         assert cards[6][0] == EncodedHandHistory.RANK_MAP["2"]  # 2s
         assert cards[6][1] == EncodedHandHistory.SUIT_MAP["s"]
         assert cards[6][2] == EncodedHandHistory.CARD_STREET_MAP["river"]
-

--- a/tests/test_encoded_handhistory.py
+++ b/tests/test_encoded_handhistory.py
@@ -1,7 +1,10 @@
-import pytest
+from pathlib import Path
+
 import numpy as np
-from models.handhistory import HandHistory, GameAction, Action, Player, Street, Actor
+import pytest
+
 from models.encoded_handhistory import EncodedHandHistory
+from models.handhistory import Action, Actor, GameAction, HandHistory, Player, Street
 
 
 class TestEncodedHandHistory:
@@ -13,36 +16,32 @@ class TestEncodedHandHistory:
                 amount=3.0,
                 player=Player.UTG,
                 street=Street.PREFLOP,
-                actor=Actor.HERO
+                actor=Actor.HERO,
             ),
             GameAction(
                 action=Action.CALL,
                 amount=3.0,
                 player=Player.BIG_BLIND,
                 street=Street.PREFLOP,
-                actor=Actor.VILLAIN
-            )
+                actor=Actor.VILLAIN,
+            ),
         ]
-        
-        hand_history = HandHistory(
-            hand=['Ah', 'Kh'],
-            board=[],
-            gameLog=game_log
-        )
-        
+
+        hand_history = HandHistory(hand=["Ah", "Kh"], board=[], gameLog=game_log)
+
         encoded = EncodedHandHistory.encode_hand_history(hand_history)
-        
+
         # Check action encoding
-        actions = encoded['actions']
+        actions = encoded["actions"]
         assert actions.shape == (2, 5)  # 2 actions, 5 features each
-        
+
         # First action (RFI)
         assert actions[0][0] == Actor.HERO.value  # actor
         assert actions[0][1] == Action.BET.value  # action
         assert actions[0][2] == 0  # bet size bucket (ignored for preflop)
         assert actions[0][3] == Street.PREFLOP.value  # street
         assert actions[0][4] == Player.UTG.value  # position
-        
+
         # Second action (Call)
         assert actions[1][0] == Actor.VILLAIN.value
         assert actions[1][1] == Action.CALL.value
@@ -58,36 +57,34 @@ class TestEncodedHandHistory:
                 amount=0.5,  # 50% of pot
                 player=Player.UTG,  # Fixed: Using position instead of HERO
                 street=Street.FLOP,
-                actor=Actor.HERO
+                actor=Actor.HERO,
             ),
             GameAction(
                 action=Action.RAISE,
                 amount=1.5,  # 150% of pot
                 player=Player.BIG_BLIND,  # Fixed: Using position instead of VILLAIN
                 street=Street.FLOP,
-                actor=Actor.VILLAIN
-            )
+                actor=Actor.VILLAIN,
+            ),
         ]
-        
+
         hand_history = HandHistory(
-            hand=['Ah', 'Kh'],
-            board=['Jh', 'Th', '2c'],
-            gameLog=game_log
+            hand=["Ah", "Kh"], board=["Jh", "Th", "2c"], gameLog=game_log
         )
-        
+
         encoded = EncodedHandHistory.encode_hand_history(hand_history)
-        
+
         # Check action encoding
-        actions = encoded['actions']
+        actions = encoded["actions"]
         assert actions.shape == (2, 5)
-        
+
         # First action (50% pot bet)
         assert actions[0][0] == Actor.HERO.value
         assert actions[0][1] == Action.BET.value
         assert actions[0][2] == 1  # bet size bucket (0.5 pot = bucket 1)
         assert actions[0][3] == Street.FLOP.value
         assert actions[0][4] == Player.UTG.value  # Fixed: Using position value
-        
+
         # Second action (150% pot raise)
         assert actions[1][0] == Actor.VILLAIN.value
         assert actions[1][1] == Action.RAISE.value
@@ -97,59 +94,59 @@ class TestEncodedHandHistory:
 
     def test_encode_cards(self):
         hand_history = HandHistory(
-            hand=['Ah', 'Kh'],  # Ace and King of hearts
-            board=['Jh', 'Th', '2c', 'Qd', 'As'],  # Flush draw board
-            gameLog=[]
+            hand=["Ah", "Kh"],  # Ace and King of hearts
+            board=["Jh", "Th", "2c", "Qd", "As"],  # Flush draw board
+            gameLog=[],
         )
-        
+
         encoded = EncodedHandHistory.encode_hand_history(hand_history)
-        cards = encoded['cards']
-        
+        cards = encoded["cards"]
+
         # Check shape (7 cards total: 2 hole + 5 board)
         assert cards.shape == (7, 3)  # 7 cards, 3 features each (rank, suit, street)
-        
+
         # Check hole cards
         # Ah
-        assert cards[0][0] == EncodedHandHistory.RANK_MAP['A']  # rank
-        assert cards[0][1] == EncodedHandHistory.SUIT_MAP['h']  # suit
-        assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP['hole']  # street
-        
+        assert cards[0][0] == EncodedHandHistory.RANK_MAP["A"]  # rank
+        assert cards[0][1] == EncodedHandHistory.SUIT_MAP["h"]  # suit
+        assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP["hole"]  # street
+
         # Kh
-        assert cards[1][0] == EncodedHandHistory.RANK_MAP['K']
-        assert cards[1][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[1][2] == EncodedHandHistory.CARD_STREET_MAP['hole']
-        
+        assert cards[1][0] == EncodedHandHistory.RANK_MAP["K"]
+        assert cards[1][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[1][2] == EncodedHandHistory.CARD_STREET_MAP["hole"]
+
         # Check board cards
         # Jh (flop)
-        assert cards[2][0] == EncodedHandHistory.RANK_MAP['J']
-        assert cards[2][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[2][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
+        assert cards[2][0] == EncodedHandHistory.RANK_MAP["J"]
+        assert cards[2][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[2][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
         # Th (flop)
-        assert cards[3][0] == EncodedHandHistory.RANK_MAP['T']
-        assert cards[3][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[3][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
+        assert cards[3][0] == EncodedHandHistory.RANK_MAP["T"]
+        assert cards[3][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[3][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
         # 2c (flop)
-        assert cards[4][0] == EncodedHandHistory.RANK_MAP['2']
-        assert cards[4][1] == EncodedHandHistory.SUIT_MAP['c']
-        assert cards[4][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
+        assert cards[4][0] == EncodedHandHistory.RANK_MAP["2"]
+        assert cards[4][1] == EncodedHandHistory.SUIT_MAP["c"]
+        assert cards[4][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
         # Qd (turn)
-        assert cards[5][0] == EncodedHandHistory.RANK_MAP['Q']
-        assert cards[5][1] == EncodedHandHistory.SUIT_MAP['d']
-        assert cards[5][2] == EncodedHandHistory.CARD_STREET_MAP['turn']
-        
+        assert cards[5][0] == EncodedHandHistory.RANK_MAP["Q"]
+        assert cards[5][1] == EncodedHandHistory.SUIT_MAP["d"]
+        assert cards[5][2] == EncodedHandHistory.CARD_STREET_MAP["turn"]
+
         # As (river)
-        assert cards[6][0] == EncodedHandHistory.RANK_MAP['A']
-        assert cards[6][1] == EncodedHandHistory.SUIT_MAP['s']
-        assert cards[6][2] == EncodedHandHistory.CARD_STREET_MAP['river']
+        assert cards[6][0] == EncodedHandHistory.RANK_MAP["A"]
+        assert cards[6][1] == EncodedHandHistory.SUIT_MAP["s"]
+        assert cards[6][2] == EncodedHandHistory.CARD_STREET_MAP["river"]
 
     def test_from_json(self):
         # Create a test JSON file
         import json
         import tempfile
-        
+
         test_data = {
             "hand": ["Ah", "Kh"],
             "board": ["Jh", "Th", "2c"],
@@ -159,189 +156,195 @@ class TestEncodedHandHistory:
                     "amount": 3.0,
                     "player": "UTG",
                     "street": "PREFLOP",
-                    "actor": "HERO"
+                    "actor": "HERO",
                 },
                 {
                     "action": "CALL",
                     "amount": 3.0,
                     "player": "BIG_BLIND",
                     "street": "PREFLOP",
-                    "actor": "VILLAIN"
-                }
-            ]
+                    "actor": "VILLAIN",
+                },
+            ],
         }
-        
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(test_data, f)
             temp_path = f.name
-        
+
         try:
             encoded = EncodedHandHistory.from_json(temp_path)
-            
+
             # Check action encoding
-            actions = encoded['actions']
+            actions = encoded["actions"]
             assert actions.shape == (2, 5)
-            
+
             # First action (RFI)
             assert actions[0][0] == Actor.HERO.value
             assert actions[0][1] == Action.BET.value
             assert actions[0][2] == 0  # bet size bucket (ignored for preflop)
             assert actions[0][3] == Street.PREFLOP.value
             assert actions[0][4] == Player.UTG.value
-            
+
             # Check card encoding
-            cards = encoded['cards']
+            cards = encoded["cards"]
             assert cards.shape == (5, 3)  # 2 hole + 3 board cards
-            
+
             # Check hole cards
-            assert cards[0][0] == EncodedHandHistory.RANK_MAP['A']
-            assert cards[0][1] == EncodedHandHistory.SUIT_MAP['h']
-            assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP['hole']
-            
+            assert cards[0][0] == EncodedHandHistory.RANK_MAP["A"]
+            assert cards[0][1] == EncodedHandHistory.SUIT_MAP["h"]
+            assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP["hole"]
+
         finally:
             # Clean up temporary file
             import os
+
             os.unlink(temp_path)
 
     def test_encode_batch(self):
         # Create multiple hand histories
         hand_histories = [
             HandHistory(
-                hand=['Ah', 'Kh'],
-                board=['Jh', 'Th', '2c'],
+                hand=["Ah", "Kh"],
+                board=["Jh", "Th", "2c"],
                 gameLog=[
                     GameAction(
                         action=Action.BET,
                         amount=3.0,
                         player=Player.UTG,
                         street=Street.PREFLOP,
-                        actor=Actor.HERO
+                        actor=Actor.HERO,
                     )
-                ]
+                ],
             ),
             HandHistory(
-                hand=['Qd', 'Qc'],
-                board=['Qs', 'Qh', '2c'],
+                hand=["Qd", "Qc"],
+                board=["Qs", "Qh", "2c"],
                 gameLog=[
                     GameAction(
                         action=Action.CHECK,
                         amount=0.0,
                         player=Player.BIG_BLIND,
                         street=Street.FLOP,
-                        actor=Actor.VILLAIN
+                        actor=Actor.VILLAIN,
                     )
-                ]
-            )
+                ],
+            ),
         ]
-        
+
         encoded_batch = EncodedHandHistory.encode_batch(hand_histories)
-        
+
         # Check batch encoding
         assert len(encoded_batch) == 2
-        
+
         # Check first hand
         first_hand = encoded_batch[0]
-        assert first_hand['actions'].shape == (1, 5)  # 1 action
-        assert first_hand['cards'].shape == (5, 3)  # 2 hole + 3 board
-        
+        assert first_hand["actions"].shape == (1, 5)  # 1 action
+        assert first_hand["cards"].shape == (5, 3)  # 2 hole + 3 board
+
         # Check second hand
         second_hand = encoded_batch[1]
-        assert second_hand['actions'].shape == (1, 5)  # 1 action
-        assert second_hand['cards'].shape == (5, 3)  # 2 hole + 3 board
+        assert second_hand["actions"].shape == (1, 5)  # 1 action
+        assert second_hand["cards"].shape == (5, 3)  # 2 hole + 3 board
 
     def test_sample_hand(self):
         """Test encoding of the sample hand from hand1.json"""
-        encoded = EncodedHandHistory.from_json('sample-hand/hand1.json')
-        
+        test_dir = Path(__file__).parent
+        sample_json_file = str((test_dir / "sample-hand") / "hand1.json")
+        encoded = EncodedHandHistory.from_json(sample_json_file)
+
         # Check action encoding
-        actions = encoded['actions']
+        actions = encoded["actions"]
         assert actions.shape == (10, 5)  # 10 actions in the hand
-        
+
         # Check first action (preflop raise)
         assert actions[0][0] == Actor.HERO.value
         assert actions[0][1] == Action.RAISE.value
         assert actions[0][2] == 0  # bet size bucket (ignored for preflop)
         assert actions[0][3] == Street.PREFLOP.value
         assert actions[0][4] == Player.DEALER.value
-        
+
         # Check second action (preflop call)
         assert actions[1][0] == Actor.VILLAIN.value
         assert actions[1][1] == Action.CALL.value
         assert actions[1][2] == 0  # bet size bucket (ignored for preflop)
         assert actions[1][3] == Street.PREFLOP.value
         assert actions[1][4] == Player.BIG_BLIND.value
-        
+
         # Check flop actions
         assert actions[2][0] == Actor.VILLAIN.value  # Check
         assert actions[2][1] == Action.CHECK.value
         assert actions[2][3] == Street.FLOP.value
-        
+
         assert actions[3][0] == Actor.HERO.value  # Bet
         assert actions[3][1] == Action.BET.value
         assert actions[3][2] == 3  # bet size bucket (1.0 pot = bucket 3)
         assert actions[3][3] == Street.FLOP.value
-        
+
         assert actions[4][0] == Actor.VILLAIN.value  # Call
         assert actions[4][1] == Action.CALL.value
         assert actions[4][2] == 3  # bet size bucket (1.0 pot = bucket 3)
         assert actions[4][3] == Street.FLOP.value
-        
+
         # Check turn actions
         assert actions[5][0] == Actor.VILLAIN.value  # Check
         assert actions[5][1] == Action.CHECK.value
         assert actions[5][3] == Street.TURN.value
-        
+
         assert actions[6][0] == Actor.HERO.value  # Bet
         assert actions[6][1] == Action.BET.value
         assert actions[6][2] == 3  # bet size bucket (1.0 pot = bucket 3)
         assert actions[6][3] == Street.TURN.value
-        
+
         assert actions[7][0] == Actor.VILLAIN.value  # Raise
         assert actions[7][1] == Action.RAISE.value
         assert actions[7][2] == 5  # bet size bucket (3.0 pot = bucket 5, >1.5 pot)
         assert actions[7][3] == Street.TURN.value
-        
+
         assert actions[8][0] == Actor.HERO.value  # Call
         assert actions[8][1] == Action.CALL.value
         assert actions[8][2] == 5  # bet size bucket (3.0 pot = bucket 5, >1.5 pot)
         assert actions[8][3] == Street.TURN.value
-        
+
         # Check river action
         assert actions[9][0] == Actor.VILLAIN.value  # Bet
         assert actions[9][1] == Action.BET.value
-        assert actions[9][2] == 4  # bet size bucket (1.25 pot = bucket 4, between 1.0-1.5 pot)
+        assert (
+            actions[9][2] == 4
+        )  # bet size bucket (1.25 pot = bucket 4, between 1.0-1.5 pot)
         assert actions[9][3] == Street.RIVER.value
-        
+
         # Check card encoding
-        cards = encoded['cards']
+        cards = encoded["cards"]
         assert cards.shape == (7, 3)  # 2 hole + 5 board cards
-        
+
         # Check hole cards
-        assert cards[0][0] == EncodedHandHistory.RANK_MAP['T']  # Ts
-        assert cards[0][1] == EncodedHandHistory.SUIT_MAP['s']
-        assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP['hole']
-        
-        assert cards[1][0] == EncodedHandHistory.RANK_MAP['9']  # 9s
-        assert cards[1][1] == EncodedHandHistory.SUIT_MAP['s']
-        assert cards[1][2] == EncodedHandHistory.CARD_STREET_MAP['hole']
-        
+        assert cards[0][0] == EncodedHandHistory.RANK_MAP["T"]  # Ts
+        assert cards[0][1] == EncodedHandHistory.SUIT_MAP["s"]
+        assert cards[0][2] == EncodedHandHistory.CARD_STREET_MAP["hole"]
+
+        assert cards[1][0] == EncodedHandHistory.RANK_MAP["9"]  # 9s
+        assert cards[1][1] == EncodedHandHistory.SUIT_MAP["s"]
+        assert cards[1][2] == EncodedHandHistory.CARD_STREET_MAP["hole"]
+
         # Check board cards
-        assert cards[2][0] == EncodedHandHistory.RANK_MAP['J']  # Jh
-        assert cards[2][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[2][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
-        assert cards[3][0] == EncodedHandHistory.RANK_MAP['Q']  # Qh
-        assert cards[3][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[3][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
-        assert cards[4][0] == EncodedHandHistory.RANK_MAP['K']  # Kh
-        assert cards[4][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[4][2] == EncodedHandHistory.CARD_STREET_MAP['flop']
-        
-        assert cards[5][0] == EncodedHandHistory.RANK_MAP['A']  # Ah
-        assert cards[5][1] == EncodedHandHistory.SUIT_MAP['h']
-        assert cards[5][2] == EncodedHandHistory.CARD_STREET_MAP['turn']
-        
-        assert cards[6][0] == EncodedHandHistory.RANK_MAP['2']  # 2s
-        assert cards[6][1] == EncodedHandHistory.SUIT_MAP['s']
-        assert cards[6][2] == EncodedHandHistory.CARD_STREET_MAP['river'] 
+        assert cards[2][0] == EncodedHandHistory.RANK_MAP["J"]  # Jh
+        assert cards[2][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[2][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
+        assert cards[3][0] == EncodedHandHistory.RANK_MAP["Q"]  # Qh
+        assert cards[3][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[3][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
+        assert cards[4][0] == EncodedHandHistory.RANK_MAP["K"]  # Kh
+        assert cards[4][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[4][2] == EncodedHandHistory.CARD_STREET_MAP["flop"]
+
+        assert cards[5][0] == EncodedHandHistory.RANK_MAP["A"]  # Ah
+        assert cards[5][1] == EncodedHandHistory.SUIT_MAP["h"]
+        assert cards[5][2] == EncodedHandHistory.CARD_STREET_MAP["turn"]
+
+        assert cards[6][0] == EncodedHandHistory.RANK_MAP["2"]  # 2s
+        assert cards[6][1] == EncodedHandHistory.SUIT_MAP["s"]
+        assert cards[6][2] == EncodedHandHistory.CARD_STREET_MAP["river"]
+

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -5,17 +5,21 @@ Script to convert a hand history JSON file to an EncodedHandHistory object.
 
 import os
 import sys
+from pathlib import Path
+
+# add git repo base path to sys.path so python3 {path to this file}
+# can correctly import models
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from models.encoded_handhistory import EncodedHandHistory
 
 
 def main():
-    # Get the JSON file path from command line arguments or use default
-    json_file = sys.argv[1] if len(sys.argv) > 1 else "../sample-hand/hand1.json"
-
-    # Ensure the file path is relative to the script directory
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    json_path = os.path.join(script_dir, json_file)
+    if len(sys.argv) > 1:
+        json_path = Path(__file__).parent / sys.argv[1]
+    else:
+        json_path = Path(__file__).parent / "sample-hand" / "hand1.json"
+    json_path = str(json_path)
 
     # Check if the file exists
     if not os.path.exists(json_path):
@@ -30,13 +34,15 @@ def main():
         # Get the encoded data
         action_sequence = encoded_data["actions"]
         card_encodings = encoded_data["cards"]
+        hole_card_encodings = card_encodings[:2, :]  # (2, 3)
+        board_card_encodings = card_encodings[2:, :]  # (5, 3)
 
         # Print information about the encoded data
         print("\nEncoded Hand History Information:")
         print(f"Number of actions: {len(action_sequence)}")
         print(f"Action sequence shape: {action_sequence.shape}")
-        print(f"Hole cards shape: {card_encodings['hole_cards'].shape}")
-        print(f"Board cards shape: {card_encodings['board_cards'].shape}")
+        print(f"Hole cards shape: {hole_card_encodings.shape}")
+        print(f"Board cards shape: {board_card_encodings.shape}")
 
         # Print the first action as an example
         if len(action_sequence) > 0:
@@ -44,9 +50,9 @@ def main():
             print(action_sequence[0])
 
         # Print the hole cards as an example
-        if len(card_encodings["hole_cards"]) > 0:
+        if len(hole_card_encodings) > 0:
             print("\nHole cards encoding:")
-            for i, card in enumerate(card_encodings["hole_cards"]):
+            for i, card in enumerate(hole_card_encodings):
                 print(f"Card {i+1}: {card}")
 
         print("\nConversion successful!")
@@ -59,4 +65,3 @@ def main():
 
 if __name__ == "__main__":
     sys.exit(main())
-

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -3,57 +3,60 @@
 Script to convert a hand history JSON file to an EncodedHandHistory object.
 """
 
-import sys
 import os
-import numpy as np
+import sys
+
 from models.encoded_handhistory import EncodedHandHistory
+
 
 def main():
     # Get the JSON file path from command line arguments or use default
-    json_file = sys.argv[1] if len(sys.argv) > 1 else '../sample-hand/hand1.json'
-    
+    json_file = sys.argv[1] if len(sys.argv) > 1 else "../sample-hand/hand1.json"
+
     # Ensure the file path is relative to the script directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
     json_path = os.path.join(script_dir, json_file)
-    
+
     # Check if the file exists
     if not os.path.exists(json_path):
         print(f"Error: File '{json_path}' not found.")
         return 1
-    
+
     try:
         # Convert the JSON file to encoded format
         print(f"Converting {json_path} to encoded format...")
         encoded_data = EncodedHandHistory.from_json(json_path)
-        
+
         # Get the encoded data
-        action_sequence = encoded_data['actions']
-        card_encodings = encoded_data['cards']
-        
+        action_sequence = encoded_data["actions"]
+        card_encodings = encoded_data["cards"]
+
         # Print information about the encoded data
         print("\nEncoded Hand History Information:")
         print(f"Number of actions: {len(action_sequence)}")
         print(f"Action sequence shape: {action_sequence.shape}")
         print(f"Hole cards shape: {card_encodings['hole_cards'].shape}")
         print(f"Board cards shape: {card_encodings['board_cards'].shape}")
-        
+
         # Print the first action as an example
         if len(action_sequence) > 0:
             print("\nFirst action encoding:")
             print(action_sequence[0])
-        
+
         # Print the hole cards as an example
-        if len(card_encodings['hole_cards']) > 0:
+        if len(card_encodings["hole_cards"]) > 0:
             print("\nHole cards encoding:")
-            for i, card in enumerate(card_encodings['hole_cards']):
+            for i, card in enumerate(card_encodings["hole_cards"]):
                 print(f"Card {i+1}: {card}")
-        
+
         print("\nConversion successful!")
         return 0
-    
+
     except Exception as e:
         print(f"Error converting hand history: {e}")
         return 1
 
+
 if __name__ == "__main__":
-    sys.exit(main()) 
+    sys.exit(main())
+

--- a/utils/create_mask_and_pad.py
+++ b/utils/create_mask_and_pad.py
@@ -1,0 +1,46 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class MaskerPadder:
+    # NOTE: Possible improvement: modify to only need to take a list of ints
+    """
+    Utility function for creating masks and padded tensor from a given list of LongTensors.
+    Intended to be called on LongTensors produced by list of actions tensors encoded_hand_history.
+
+    Args:
+        validate_input: use True in testing, validates shapes
+    Input:
+        x: length B list of long tensors of shape (E, ) to create mask and padded versions of x
+           (where E = action embedding dim)
+    Returns:
+        tuple[x_mask, x_padded]
+        where:
+            x_mask: torch.BoolTensor of shape (B, T)
+            x_padded: torch.BoolTensor of shape (B, T, E)
+    """
+
+    validate_input: bool = False
+
+    def forward(
+        self, x: Sequence[torch.LongTensor]
+    ) -> tuple[torch.BoolTensor, torch.LongTensor]:
+        if self.validate_input:
+            self.validate(x)
+        x_lens = list(map(len, x))
+        T = max(x_lens)  # same as T
+        B = len(x)  # same as B
+        x_mask = torch.arange(T)[None, :] >= torch.tensor(x_lens)[:, None]
+        x_padded = torch.nn.utils.rnn.pad_sequence(x, batch_first=True)
+        return (x_mask, x_padded)
+
+    def __call__(self, x: Sequence[torch.LongTensor]) -> torch.BoolTensor:
+        return self.forward(x)
+
+    @staticmethod
+    def validate(x: Sequence[torch.LongTensor]):
+        assert set([len(xx.shape) for xx in x]) == {2}
+        assert len(set([xx.shape[-1] for xx in x])) == 1

--- a/utils/custom_nn_modules.py
+++ b/utils/custom_nn_modules.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import override
 
 import torch
@@ -45,7 +46,7 @@ class CombinedEncoder(nn.Module):
     and apply to each slice of tensor.
     """
 
-    def __init__(self, encoder_list: list[nn.Module]) -> None:
+    def __init__(self, encoder_list: Sequence[nn.Module]) -> None:
         super().__init__()
         self.encoder_module_list: nn.ModuleList = nn.ModuleList(
             [encoder for encoder in encoder_list]

--- a/utils/custom_torch_data_utils.py
+++ b/utils/custom_torch_data_utils.py
@@ -1,0 +1,79 @@
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TypedDict, override
+
+import torch
+from torch.utils.data import Dataset
+
+from models.encoded_handhistory import EncodedHandHistory, EncodedHandHistoryType
+from models.model_config import ModelConfig
+from utils.create_mask_and_pad import MaskerPadder
+
+
+class JSONDatasetType(TypedDict):
+    encoded_hand_history: EncodedHandHistoryType
+    expected_ev: float
+
+
+class JSONDatasetTypeCollated(TypedDict):
+    expected_ev: torch.Tensor
+    cards: torch.LongTensor
+    actions_padded: torch.LongTensor
+    actions_mask: torch.BoolTensor
+
+
+class JSONDatasetBase(Dataset[JSONDatasetType]):
+    """
+    torch.utils.Dataset for loading json files, assuming each
+    json contains one action and on hand seq (like hand1.json).
+
+    This basic one loads from the same file 500 times.
+    torch.utils.data has other variants of Dataset classes.
+
+    Attributes:
+        root_dir (pathlib.Path): root directory for json files
+        expected_ev_list (list[float]): list of "ground truth" expected values
+        training_files_list (list[str]): list of training file names
+    """
+
+    root_dir: Path
+    expected_ev_list: list[float]
+    training_files_list: list[str]
+
+    def __init__(self, config: ModelConfig = ModelConfig()):
+        self.root_dir = Path(__file__).parent.parent / "tests" / "sample-hand"
+        self.expected_ev_list = [
+            -0.42069 + i * 0.002 for i in range(500)
+        ]  # should depend on config (which phase of training)
+        self.training_files_list = ["hand1.json"] * 500
+
+    def __len__(self):
+        return len(self.expected_ev_list)
+
+    @override
+    def __getitem__(self, idx: int) -> JSONDatasetType:
+        json_path = str(self.root_dir / self.training_files_list[idx])
+        return {
+            "encoded_hand_history": EncodedHandHistory.from_json(json_path),
+            "expected_ev": self.expected_ev_list[idx],
+        }
+
+
+def CollateFnForJSONDatasetType(
+    xx: Sequence[JSONDatasetType],
+) -> JSONDatasetTypeCollated:
+    """
+    util function for collating JSONDatasetType outputs
+    useful for combining sequence of JSONDatasetType
+    to be passed into torch.utils.data.DataLoader
+    """
+    masker_padder = MaskerPadder()
+    actions_mask, actions_padded = masker_padder(
+        [x["encoded_hand_history"]["actions"] for x in xx]
+    )
+    return {
+        "expected_ev": torch.Tensor([x["expected_ev"] for x in xx]),
+        "cards": torch.stack([x["encoded_hand_history"]["cards"] for x in xx], dim=0),
+        "actions_padded": actions_padded,
+        "actions_mask": actions_mask,
+    }


### PR DESCRIPTION
this PR in summary has the following changes:

1. expanded model config params, and updated some originally hard-coded integers in models.
2. added more type hinting using `TypedDict`
3. modified attention-related models to take key padding mask arguments (action sequences most likely need this)
4. added masking and padding creation utility (in `utils/create_mask_and_pad.py`)
5. added custom data utils that builds on top of `torch.utils.data.Dataset` and `Dataloader` (in `utils/custom_torch_data_utils.py`)
6. added tests for item 4, 5, with the test `tests/test_custom_torch_data_utils.py` showing a boilerplate for creating batched inputs ready for our full_model to take in.